### PR TITLE
bridge: mirror agent status across the cross-host bridge

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,7 +114,7 @@ Both ends run identical bridge logic. `connect` owns the SSH process and the rec
 
 ### The core trick: reuse inboxes as the outbound queue
 
-The bridge **mirrors the peer's live agents into the local registry**, qualified by host (`agent-X@hostB`) and owned by the bridge's own PID. Everything else falls out of the existing primitives with no MCP changes:
+The bridge **mirrors the peer's live agents into the local registry**, qualified by host (`agent-X@hostB`) and owned by the bridge's own PID. Both self-set presence fields cross the bridge: a mirrored entry carries the remote agent's `focus` *and* its `status`, so the "who needs a human" scan over `list_agents` (`status ∈ {needs_input, blocked}`) sees remote agents exactly as it sees local ones. Everything else falls out of the existing primitives with no MCP changes:
 
 - A local agent sends to `agent-X@hostB` → ordinary `send_message` → lands in `inboxes/agent-X@hostB.jsonl` locally.
 - The bridge tails every `*@hostB` inbox and forwards new lines over the pipe.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -191,9 +191,12 @@ For each live agent on the peer, the bridge writes a registry entry on the local
   "working_dir": "...",
   "pid": <bridge's own pid>,
   "pid_start": <bridge's own start-time>,
-  "focus": "..."
+  "focus": "...",
+  "status": "..."
 }
 ```
+
+Both self-set presence fields are carried through: `focus` and `status` are mirrored from the peer's entry as-is, so a remote agent's `needs_input`/`blocked` is visible to a local `list_agents` scan. They inherit the same bounded staleness as everything else in the snapshot — a change on the peer (including the `status` reset on re-registration) reaches the mirror on the next registry sync.
 
 `pid`/`pid_start` are the **bridge's**, not the remote process's (whose PID is meaningless locally). So `is_stale` treats a mirrored entry as live exactly while the bridge is alive — if the pipe/bridge dies, every mirrored entry goes stale and remote agents drop out of `list_agents`. The bridge refreshes the set on each registry sync from the peer (adding new agents, removing departed ones).
 

--- a/src/spanreed/store.py
+++ b/src/spanreed/store.py
@@ -296,6 +296,7 @@ class StateStore:
                 pid_start=owner_pid_start,
                 last_seen=now,
                 focus=a.focus,
+                status=a.status,
             )
             for a in remote_agents
         ]

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -381,6 +381,7 @@ class TestBridgePrimitives:
             pid=999_999,  # the remote's pid, meaningless locally
             last_seen=datetime.now(UTC),
             focus="doing things",
+            status="blocked",
         )
         owner_start = store_module.pid_start_time(os.getpid())
         store.sync_remote_agents(
@@ -391,6 +392,9 @@ class TestBridgePrimitives:
         # Mirrored entry rides the bridge's pid, so it's live while the bridge is.
         assert listed["agent-x@hostB"].pid == os.getpid()
         assert listed["agent-x@hostB"].focus == "doing things"
+        # status crosses the bridge alongside focus, so "who needs a human" sees
+        # remote agents too.
+        assert listed["agent-x@hostB"].status == "blocked"
 
     def test_sync_remote_agents_replaces_previous_snapshot(self, store: StateStore) -> None:
         a = Agent(


### PR DESCRIPTION
Closes #6 (approved health-suggestion).

## What

`StateStore.sync_remote_agents` mirrored a remote agent's `focus` into the local registry but silently dropped `status`, so every `agent-X@peer` entry read `status: null` regardless of what the remote agent had set.

## Why it matters

`status` exists for one job: the pull-mode "who needs a human" scan over `list_agents` (`status ∈ {needs_input, blocked}`). Dropping it at the bridge made that scan blind to remote agents — a `blocked` peer on another host was invisible to a human scanning the local fleet view, which is precisely the cross-host case the bridge exists to serve. `focus` was mirrored; `status` being absent read as an oversight rather than a decision (architecture.md describes status as "a sibling of `focus`, not new infrastructure", and the bridge docs claimed it "mirrors the peer's live agents" with no carve-out).

## Changes

- `src/spanreed/store.py` — add `status=a.status` to the mirrored `Agent(...)`.
- `docs/architecture.md` — state explicitly that both self-set presence fields cross the bridge, so the intended behavior is documented rather than implied (CLAUDE.md rule 1: registry state carried across the bridge is a doc-first change).
- `tests/unit/test_store.py` — extend the existing bridge-mirror test to set `status="blocked"` on the remote agent and assert the mirrored entry carries it, alongside the existing focus assertion.

## Verification

- `make check` green: ruff, pyright (0 errors), 139 tests pass.
- Confirmed the test is load-bearing: with the one-line `store.py` change stashed, `test_sync_remote_agents_mirrors_with_owner_pid` fails on `status=None`. It passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BBLGX2riVjxco6khkiabF