### PR TITLE
cli: collapse redundant identity branch in register

### DIFF
--- a/src/spanreed/cli.py
+++ b/src/spanreed/cli.py
@@ -40,11 +40,9 @@ def _cmd_inbox_path(args: argparse.Namespace) -> int:
 
 def _cmd_register(args: argparse.Namespace) -> int:
     wd = Path(args.working_dir) if args.working_dir else Path.cwd()
-    if args.agent_id or args.name:
-        agent_id = args.agent_id or derive_agent_identity(wd)[0]
-        name = args.name or derive_agent_identity(wd)[1]
-    else:
-        agent_id, name = derive_agent_identity(wd)
+    derived_id, derived_name = derive_agent_identity(wd)
+    agent_id = args.agent_id or derived_id
+    name = args.name or derived_name
     pid = args.pid if args.pid is not None else os.getppid()
     agent = StateStore().register_agent(name=name, working_dir=str(wd), pid=pid, agent_id=agent_id)
     json.dump(agent.model_dump(mode="json"), sys.stdout, indent=2)


### PR DESCRIPTION
Closes #7 (approved health-suggestion).

## What

`_cmd_register` had an `if/else` on `args.agent_id or args.name` where the `if`-branch expressions already reduce to the `else`-branch result when both overrides are absent:

```python
if args.agent_id or args.name:
    agent_id = args.agent_id or derive_agent_identity(wd)[0]
    name = args.name or derive_agent_identity(wd)[1]
else:
    agent_id, name = derive_agent_identity(wd)
```

Now:

```python
derived_id, derived_name = derive_agent_identity(wd)
agent_id = args.agent_id or derived_id
name = args.name or derived_name
```

Five lines and a dead branch become three, and the "explicit override wins, else derive" intent reads directly off the two `or` lines.

## Correction to this PR's original rationale

The first version of this PR (and issue #7 itself) claimed the old code called `derive_agent_identity` "up to three times, twice in the if-branch when both overrides are set." **That is false, and backwards.** Python's `or` short-circuits, so:

| `--agent-id` | `--name` | old calls | new calls | same result |
|---|---|---|---|---|
| set | set | **0** | 1 | yes |
| set | unset | 1 | 1 | yes |
| unset | set | 1 | 1 | yes |
| unset | unset | 1 | 1 | yes |
| `""` | `""` | 1 | 1 | yes |
| `""` | set | 1 | 1 | yes |

The old code never called it more than once, and called it **zero** times in exactly the case the original claim singled out as the worst offender. The new code calls it unconditionally once — so this is a wash at worst, not a saving. The commit message has been corrected to say so; this body is corrected to match.

The honest justification is readability, not performance: a branch that carries no semantics is gone.

## Verification

- Behavioral equivalence confirmed across all 8 combinations of `(args.agent_id, args.name)` including falsy-but-present empty strings — output values byte-identical, verified by instrumenting call counts on both versions rather than by reasoning alone.
- `Path.resolve(strict=False)` does not raise for a nonexistent `--working-dir`, so the now-unconditional derive is not a crash regression on a path the old short-circuit skipped.
- `make check` green: ruff, pyright (0 errors), 139 tests pass.
- Behavior pinned by existing register cases in `tests/integration/test_cli.py`. No new test: pure refactor, no new code path (CLAUDE.md rule 2).
- CLI-internal only — no wire-format, MCP-surface, or filesystem-layout impact, so no doc change owed under rule 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BBLGX2riVjxco6khkiabF