### PR TITLE
tests: cover the --since grammar, both accepted shapes

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -535,3 +536,59 @@ class TestActivityLog:
     ) -> None:
         rc, _ = _run(capsys, ["log", "--since", "5x"])
         assert rc == 2
+
+
+# Aliased once so the private stays private: the parser has its own grammar
+# worth pinning directly, and one alias costs a single ignore instead of one
+# per call site.
+_parse_since = cli._parse_since  # pyright: ignore[reportPrivateUsage]
+
+
+class TestParseSince:
+    """The ``--since`` grammar: a relative age, or an ISO-8601 timestamp.
+
+    Colocated with the ``log --since`` CLI case above so all ``--since``
+    behavior reads in one place. ``_parse_since`` is a pure function — no bus
+    state — so these need no ``cli_env``.
+    """
+
+    @pytest.mark.parametrize(
+        ("value", "delta"),
+        [
+            ("30m", timedelta(minutes=30)),
+            ("24h", timedelta(hours=24)),
+            ("7d", timedelta(days=7)),
+            ("90m", timedelta(minutes=90)),
+        ],
+    )
+    def test_relative_age_backs_off_from_now(self, value: str, delta: timedelta) -> None:
+        before = datetime.now(UTC)
+        parsed = _parse_since(value)
+        after = datetime.now(UTC)
+        # Bracket the call rather than assert an exact instant: `now` moves.
+        assert before - delta <= parsed <= after - delta
+
+    def test_iso_with_offset_preserves_instant(self) -> None:
+        parsed = _parse_since("2026-07-27T12:00:00+02:00")
+        assert parsed == datetime(2026, 7, 27, 10, 0, tzinfo=UTC)
+
+    def test_iso_naive_is_coerced_to_utc(self) -> None:
+        """A naive timestamp is read as UTC, not as local time."""
+        parsed = _parse_since("2026-07-27T12:00:00")
+        assert parsed.tzinfo is not None
+        assert parsed == datetime(2026, 7, 27, 12, 0, tzinfo=UTC)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "5x",  # unknown unit
+            "",  # empty
+            "h",  # unit with no magnitude (len < 2, falls through to ISO)
+            "90",  # magnitude with no unit (falls through to ISO)
+            "-1h",  # non-digit magnitude (falls through to ISO)
+            "1.5h",  # fractional magnitude is not supported
+        ],
+    )
+    def test_malformed_raises_value_error(self, value: str) -> None:
+        with pytest.raises(ValueError):
+            _parse_since(value)


### PR DESCRIPTION
Closes #8 (approved health-suggestion).

## What

`--since` accepts two shapes — a relative age (`24h`/`30m`/`7d`) and an ISO-8601 timestamp with a naive→UTC fixup — but the only test was `test_log_invalid_since_errors` (`5x` → exit 2). Every correct branch was uncovered.

Adds `TestParseSince` (12 cases):
- relative age for `30m`/`24h`/`7d`/`90m`, asserted by bracketing the call between two `now` reads rather than pinning an exact instant;
- ISO with an offset resolves to the right absolute instant;
- a naive ISO timestamp comes back tz-aware in UTC (not coerced to local time);
- malformed inputs raise `ValueError`: `5x`, `""`, `h` (unit, no magnitude), `90` (magnitude, no unit), `-1h` and `1.5h` (non-digit magnitude). These pin the `len(value) >= 2 and value[-1] in units and value[:-1].isdigit()` guard's fall-through to the ISO branch.

## Test-only, as scoped

`src/` is untouched — `git diff main --stat -- src/` is empty.

pyright runs `typeCheckingMode = "strict"` over `tests/` as well as `src/`, so reaching for the private parser trips `reportPrivateUsage`. This aliases it once at module level with a single `# pyright: ignore[reportPrivateUsage]` rather than one per call site.

An earlier revision of this PR instead renamed `_parse_since` → `parse_since`, making it public. That was reverted: the reviewer correctly flagged it as scope creep against #8's explicit test-only framing, and pointed out the single-alias option, which is strictly less invasive. The owner chose the alias.

## Verification

- `make check` green: ruff, pyright (0 errors), 151 tests pass — up from 139.
- Mutation-tested by the reviewer: swapping the `m`/`h` unit mapping turns 3 of 4 relative-age tests RED; changing the digit slice `value[:-1]` → `value[:-2]` turns all 4 RED. The tests kill both mutants, so they guard the grammar rather than merely executing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BBLGX2riVjxco6khkiabF