### PR TITLE
spike: price #18 — force owner-only modes on bus state (DO NOT MERGE)

### DIFF
--- a/src/spanreed/store.py
+++ b/src/spanreed/store.py
@@ -37,6 +37,34 @@ class _RegistryDoc(BaseModel):
 
 _DEFAULT_POLL_INTERVAL_S = 0.1
 
+_DIR_MODE = 0o700
+"""Owner-only on every directory under the state root."""
+
+_FILE_MODE = 0o600
+"""Owner-only on every file under the state root."""
+
+
+def _secure_dir(path: Path) -> None:
+    """Create ``path`` if absent and force owner-only permissions.
+
+    ``mkdir(mode=...)`` only applies its mode when it actually creates the
+    directory, so an existing 0755 state root from an older install keeps its
+    mode forever. Chmod unconditionally so an upgrade tightens in place.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    path.chmod(_DIR_MODE)
+
+
+def _secure_file(path: Path) -> None:
+    """Force owner-only permissions on an existing file. No-op if absent.
+
+    Files reached via ``open("a")`` are created as ``0o666 & ~umask`` — the
+    umask being whatever the Claude Code session happened to inherit, which is
+    not something this package controls. Chmod after the write instead.
+    """
+    with contextlib.suppress(FileNotFoundError):
+        path.chmod(_FILE_MODE)
+
 
 def default_state_root() -> Path:
     """Where state lives by default. Override via ``SPANREED_STATE_ROOT`` env var."""
@@ -113,11 +141,11 @@ class StateStore:
 
     def __init__(self, root: Path | None = None) -> None:
         self.root = root or default_state_root()
-        self.root.mkdir(parents=True, exist_ok=True)
+        _secure_dir(self.root)
         self._inboxes_dir = self.root / "inboxes"
         self._cursors_dir = self.root / "cursors"
-        self._inboxes_dir.mkdir(exist_ok=True)
-        self._cursors_dir.mkdir(exist_ok=True)
+        _secure_dir(self._inboxes_dir)
+        _secure_dir(self._cursors_dir)
         self._registry_path = self.root / "registry.json"
         self._registry_lock_path = self.root / "registry.lock"
         self._config_path = self.root / "config.json"
@@ -129,6 +157,7 @@ class StateStore:
     def _registry_lock(self) -> Generator[None, None, None]:
         """Exclusive advisory lock on the registry (fcntl-based, single-host)."""
         self._registry_lock_path.touch(exist_ok=True)
+        _secure_file(self._registry_lock_path)
         fd = os.open(self._registry_lock_path, os.O_RDONLY)
         try:
             fcntl.flock(fd, fcntl.LOCK_EX)
@@ -148,6 +177,7 @@ class StateStore:
         tmp = self._registry_path.with_suffix(".json.tmp")
         tmp.write_text(_RegistryDoc(agents=agents).model_dump_json(indent=2))
         tmp.replace(self._registry_path)
+        _secure_file(self._registry_path)
 
     def register_agent(
         self,
@@ -377,6 +407,7 @@ class StateStore:
         inbox = self._inbox_path(to_agent)
         with inbox.open("a") as f:
             f.write(msg.model_dump_json() + "\n")
+        _secure_file(inbox)
         return msg
 
     def append_message(self, msg: Message) -> None:
@@ -396,6 +427,7 @@ class StateStore:
         inbox = self._inbox_path(msg.to_agent)
         with inbox.open("a") as f:
             f.write(msg.model_dump_json() + "\n")
+        _secure_file(inbox)
 
     def recv_messages(
         self,
@@ -442,6 +474,7 @@ class StateStore:
         tmp = path.with_suffix(".tmp")
         tmp.write_text(msg_id)
         tmp.replace(path)
+        _secure_file(path)
 
     # ------------------------------------------------------------------ config
 
@@ -484,6 +517,7 @@ class StateStore:
         tmp = self._config_path.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(config, indent=2))
         tmp.replace(self._config_path)
+        _secure_file(self._config_path)
 
     # ------------------------------------------------------------------ activity log
 
@@ -506,6 +540,7 @@ class StateStore:
         )
         with self._activity_log_path.open("a") as f:
             f.write(record.model_dump_json() + "\n")
+        _secure_file(self._activity_log_path)
 
     def read_activity(
         self,


### PR DESCRIPTION
**Draft — explicitly not for merge.** A speculative build to price #18, per the fleet's speculative-build call. The decision stays the owner's; this only makes it a comparison instead of an unknown.

#18 asks whether the bus should set owner-only modes on its own state rather than inheriting confinement from `$HOME` being `0700`. The open question was **is this free, or does it need a migration?**

## The answer: not free. It needs a migration step, and without one it silently under-delivers.

```
BEFORE (simulated existing 0.0.8 install)
  state root 0755   inboxes/ 0755   registry.json 0644   agent-old.jsonl 0644

AFTER merely constructing StateStore()
  state root 0700   inboxes/ 0700   registry.json 0644   agent-old.jsonl 0644

AFTER a write
  state root 0700   inboxes/ 0700   registry.json 0600   agent-old.jsonl 0644   <-- still loose
```

Directories tighten on construction. Files tighten **only when written**. So an inbox belonging to an agent that never sends again keeps `0644` indefinitely — and that is precisely where historical message content lives. On the live bus that is **30 inbox files**, most belonging to sessions that have ended.

Shipping this as-is would produce a state root that *looks* hardened, with the majority of the actual content still world-readable. That is a worse outcome than not doing it, because it removes the reason to look again.

## The fix, and its measured cost

A one-time sweep in `__init__`:

```
StateStore() construction, no sweep :  0.09 ms
one-time sweep of 30 files          :  0.40 ms
```

`StateStore` is constructed **per MCP tool call**, so a sweep in `__init__` costs 0.40 ms on every call — negligible against an MCP round-trip, but it is O(files) forever to fix a one-time problem, and it grows with inbox count. Alternatives: sweep once behind a marker file, or do it in `spanreed` CLI startup rather than the library. **I have not implemented any of them** — that choice depends on whether #18 is wanted at all.

## What this establishes

- All gates green: `ruff format --check`, `ruff check`, `pyright` (0 errors), **151 tests pass** in 2.7s.
- Every newly created path lands at `0700`/`0600` — verified by walking the tree, not by reading the code.
- **The cross-host bridge is unaffected**: `test_bridge.py` 4/4 pass. Two processes, same uid, so `0700` costs nothing there. This was an open worry in #18 and it is now closed.
- Diff is 38 insertions across 7 call sites in one file.

## What this does NOT establish

- Whether the tightening is *worth doing*. `$HOME` is `0700` today, so there is no live exposure; #18 is defence-in-depth against a plausible future `chmod`. Nothing here argues it is urgent.
- Whether existing installs should be migrated at all, versus tightening only fresh ones and documenting the difference.
- Behaviour on macOS or any non-POSIX filesystem. Untested.
- Whether `spanreed-mcp`'s log directory should get the same treatment — it is outside `StateStore` and I did not touch it.

## The case for NOT taking this

Stated deliberately, because a built thing creates pressure to accept it and I am the worst-placed person to judge that.

The bus has **no live exposure**: `$HOME` is `0700`, no other uid can traverse to any of it, and this is a single-user box. This change buys protection against a hypothetical future `chmod` on a directory spanreed does not own and cannot monitor — and if that `chmod` ever happens, far more than the bus is exposed.

Against that it adds a permissions concern to seven call sites in the hottest file in the package, plus an unresolved migration question, plus a per-call cost if the sweep goes in `__init__`. `store.py` is currently clean of anything that isn't bus semantics.

**A defensible answer for #18 is to accept the risk deliberately and document it, recording it in `docs/open-questions.md` next to the bridge trust boundary at `open-questions.md:35`, and drop this branch.** That would cost one paragraph and leave the code simpler. I would not argue with it.

If the answer is instead "do it," the migration question above has to be settled first, and this branch should be treated as a starting point rather than a candidate.

