### PR TITLE
bridge: validate the peer's self-declared host before routing on it

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -209,6 +209,7 @@ A message addressed to `agent-X@hostB` is delivered by the normal `send_message`
 The pipe carries newline-delimited JSON frames, each with a `kind`:
 
 ```json
+{"kind": "hello", "host": "<the sender's own host label>"}
 {"kind": "msg", "message": { <Message, addresses in RECEIVER's namespace> }}
 {"kind": "registry", "agents": [ <Agent, ...> ]}
 {"kind": "ping"}
@@ -216,7 +217,9 @@ The pipe carries newline-delimited JSON frames, each with a `kind`:
 
 - `msg` — a forwarded bus message. The receiving bridge appends `message` verbatim to `inboxes/<message.to_agent>.jsonl`.
 - `registry` — the sender's current set of live local agents (bare ids, home = sender). The receiver mirrors them per "Mirrored registry entries" above. Sent on connect and whenever the local set changes.
-- `hello` — the sender's own host label, which becomes the `@host` suffix for every id it owns. **Validated on receipt**: alphanumeric at both ends, `.`/`-`/`_` inside, at most 253 characters. A label failing that is refused and the bridge exits rather than routing on it — the receiver interpolates this value into a filesystem glob when selecting outbound inboxes, so a metacharacter is a wildcard rather than a name.
+- `hello` — the sender's own host label, which becomes the `@host` suffix for every id it owns. Sent once, first, by both ends. **Validated on receipt**: alphanumeric at both ends, `.`/`-`/`_` inside, at most 253 characters. The receiver interpolates this value into a filesystem glob when selecting outbound inboxes, so a metacharacter would be a wildcard rather than a name.
+
+  On a label that fails validation the receiver **sends nothing further and closes**. Specifically, it does **not** send a `registry` frame — that frame carries agent ids, display names, absolute working directories, pids and focus text, and a peer whose identity was just rejected must not receive it. `hello` is the only frame a refused peer ever sees, and it was already in flight. The refusal is reported on stderr, naming the rule and the `--label` override; stdout is the pipe and carries nothing but frames.
 - `ping` — keepalive; lets each side detect a dead pipe and lets `connect` trigger reconnect.
 
 ### Address rewriting (done by the sending bridge)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -216,6 +216,7 @@ The pipe carries newline-delimited JSON frames, each with a `kind`:
 
 - `msg` — a forwarded bus message. The receiving bridge appends `message` verbatim to `inboxes/<message.to_agent>.jsonl`.
 - `registry` — the sender's current set of live local agents (bare ids, home = sender). The receiver mirrors them per "Mirrored registry entries" above. Sent on connect and whenever the local set changes.
+- `hello` — the sender's own host label, which becomes the `@host` suffix for every id it owns. **Validated on receipt**: alphanumeric at both ends, `.`/`-`/`_` inside, at most 253 characters. A label failing that is refused and the bridge exits rather than routing on it — the receiver interpolates this value into a filesystem glob when selecting outbound inboxes, so a metacharacter is a wildcard rather than a name.
 - `ping` — keepalive; lets each side detect a dead pipe and lets `connect` trigger reconnect.
 
 ### Address rewriting (done by the sending bridge)

--- a/src/spanreed/bridge.py
+++ b/src/spanreed/bridge.py
@@ -134,7 +134,11 @@ class Bridge:
                     # reaches Path.glob(); "*" there matches every host-qualified
                     # inbox, including mail queued for an unrelated peer.
                     print(
-                        f"spanreed: peer declared an invalid host {host!r}; refusing bridge",
+                        f"spanreed: peer declared an invalid host label {host!r}; "
+                        "refusing the bridge. A label must be alphanumeric at both "
+                        "ends with only '.', '-' or '_' inside, at most 253 chars. "
+                        "Override the peer's advertised label with "
+                        "`spanreed conjoin --serve --label <name>`.",
                         file=sys.stderr,
                     )
                     self._stop.set()
@@ -190,16 +194,22 @@ class Bridge:
         if not self._hello.wait(timeout=15.0):
             self._stop.set()
             return time.monotonic() - started
-        if self._stop.is_set():
-            # The reader refused the peer and set _hello only to release the
-            # wait above. Return before advertising anything: the registry frame
-            # carries agent ids, display names, absolute working directories,
-            # pids and focus text, and a peer we just hung up on must not get it.
-            return time.monotonic() - started
-        self._last_recv = time.monotonic()
-        self._send_registry()
-        last_sync = time.monotonic()
         try:
+            if self.peer_host is None:
+                # The reader refused the peer and set _hello only to release the
+                # wait above. Return before advertising anything: the registry
+                # frame carries agent ids, display names, absolute working
+                # directories, pids and focus text, and a peer we just hung up
+                # on must not get it.
+                #
+                # Keyed on peer_host rather than _stop because _stop is also set
+                # by a plain EOF, which can land here after a VALID hello — and
+                # that case has mirrored entries to tear down. Inside the try so
+                # the finally runs either way.
+                return time.monotonic() - started
+            self._last_recv = time.monotonic()
+            self._send_registry()
+            last_sync = time.monotonic()
             while not self._stop.is_set():
                 self._forward_outbound()
                 now = time.monotonic()

--- a/src/spanreed/bridge.py
+++ b/src/spanreed/bridge.py
@@ -134,11 +134,15 @@ class Bridge:
                     # reaches Path.glob(); "*" there matches every host-qualified
                     # inbox, including mail queued for an unrelated peer.
                     print(
-                        f"spanreed: peer declared an invalid host label {host!r}; "
-                        "refusing the bridge. A label must be alphanumeric at both "
-                        "ends with only '.', '-' or '_' inside, at most 253 chars. "
-                        "Override the peer's advertised label with "
-                        "`spanreed conjoin --serve --label <name>`.",
+                        f"spanreed: the peer advertised an invalid host label {host!r}; "
+                        "refusing the bridge. A label must be alphanumeric at both ends "
+                        "with only '.', '-' or '_' inside, and at most 253 characters. "
+                        "The label belongs to the OTHER end, so it has to be fixed "
+                        "there: pass --label to whichever `spanreed conjoin` runs on "
+                        "that machine, or change its hostname. Caveat: `conjoin <host>` "
+                        "launches the remote end with no way to pass --label, so a peer "
+                        "on the serve side may have no remedy but its hostname "
+                        "(spanreed#27).",
                         file=sys.stderr,
                     )
                     self._stop.set()

--- a/src/spanreed/bridge.py
+++ b/src/spanreed/bridge.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import random
+import re
 import shlex
 import signal
 import socket
@@ -31,6 +32,23 @@ from typing import IO
 
 from spanreed.protocol import Agent, Message
 from spanreed.store import StateStore, pid_start_time
+
+_HOST_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?")
+"""A plausible host label: alphanumeric ends, dots/hyphens/underscores inside.
+
+Deliberately permissive about what a hostname may contain — an SSH target can be
+an alias from ``~/.ssh/config`` rather than a DNS name — and strict about what it
+may NOT: no glob metacharacters, no ``/``, no whitespace, not empty.
+"""
+
+
+def _is_valid_host(host: str) -> bool:
+    """True if ``host`` is safe to use as a routing suffix and a glob literal.
+
+    The peer chooses this string and we interpolate it into ``Path.glob`` and
+    into ``@``-suffix comparisons. A ``*`` there is a wildcard, not a name.
+    """
+    return len(host) <= 253 and _HOST_RE.fullmatch(host) is not None
 
 
 def _qualify_from(from_agent: str, self_host: str) -> str:
@@ -107,7 +125,19 @@ class Bridge:
                 continue
             self._last_recv = time.monotonic()  # any frame proves the pipe is alive
             if kind == "hello":
-                self.peer_host = str(frame["host"])
+                host = str(frame["host"])
+                if not _is_valid_host(host):
+                    # Refuse the connection rather than routing on it. This value
+                    # reaches Path.glob(); "*" there matches every host-qualified
+                    # inbox, including mail queued for an unrelated peer.
+                    print(
+                        f"spanreed: peer declared an invalid host {host!r}; refusing bridge",
+                        file=sys.stderr,
+                    )
+                    self._stop.set()
+                    self._hello.set()  # unblock run()'s wait so it exits promptly
+                    return
+                self.peer_host = host
                 self._hello.set()
             elif kind == "msg":
                 self.store.append_message(Message.model_validate(frame["message"]))

--- a/src/spanreed/bridge.py
+++ b/src/spanreed/bridge.py
@@ -36,9 +36,12 @@ from spanreed.store import StateStore, pid_start_time
 _HOST_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?")
 """A plausible host label: alphanumeric ends, dots/hyphens/underscores inside.
 
-Deliberately permissive about what a hostname may contain — an SSH target can be
-an alias from ``~/.ssh/config`` rather than a DNS name — and strict about what it
-may NOT: no glob metacharacters, no ``/``, no whitespace, not empty.
+This validates the label a peer *advertises for itself* (usually its
+``gethostname()``, or whatever ``--label`` overrides it with) — not the SSH
+target we dialled. Deliberately permissive about what such a name may contain,
+since it can be an mDNS ``.local`` name, an IPv4 literal or a container name,
+and strict about what it may NOT: no glob metacharacters, no ``/``, no
+whitespace, not empty.
 """
 
 
@@ -186,6 +189,12 @@ class Bridge:
         reader.start()
         if not self._hello.wait(timeout=15.0):
             self._stop.set()
+            return time.monotonic() - started
+        if self._stop.is_set():
+            # The reader refused the peer and set _hello only to release the
+            # wait above. Return before advertising anything: the registry frame
+            # carries agent ids, display names, absolute working directories,
+            # pids and focus text, and a peer we just hung up on must not get it.
             return time.monotonic() - started
         self._last_recv = time.monotonic()
         self._send_registry()

--- a/src/spanreed/bridge.py
+++ b/src/spanreed/bridge.py
@@ -206,10 +206,22 @@ class Bridge:
                 # directories, pids and focus text, and a peer we just hung up
                 # on must not get it.
                 #
-                # Keyed on peer_host rather than _stop because _stop is also set
-                # by a plain EOF, which can land here after a VALID hello — and
-                # that case has mirrored entries to tear down. Inside the try so
-                # the finally runs either way.
+                # Two independent properties here, and it is worth not
+                # confusing them:
+                #
+                # Inside the `try` so the `finally` runs. `_stop` is also set by
+                # a plain EOF, which can land here after a VALID hello, and that
+                # case has mirrored entries to tear down; an early return above
+                # the `try` skipped `clear_remote_agents` for it.
+                #
+                # Keyed on `peer_host` because that is what the branch is
+                # actually about — "we never accepted this peer" — where `_stop`
+                # only means "stop". Either change alone closes the teardown
+                # hole; both are kept because the predicate is the honest one
+                # and the placement is the robust one. They do diverge: an
+                # external stop() between the hello and this guard sets `_stop`
+                # with a valid peer_host, and only the `peer_host` form still
+                # advertises the registry. Neither is wrong; they are different.
                 return time.monotonic() - started
             self._last_recv = time.monotonic()
             self._send_registry()

--- a/tests/integration/test_bridge.py
+++ b/tests/integration/test_bridge.py
@@ -322,12 +322,23 @@ class TestPeerHostValidation:
     def test_eof_after_a_valid_hello_still_tears_down_mirrored_entries(
         self, tmp_path: Path
     ) -> None:
-        """The refusal guard must key on ``peer_host``, not on ``_stop``.
+        """An EOF after a *valid* hello must still tear down mirrored entries.
 
-        ``_stop`` is set by a plain EOF too, and an EOF can land *after* a valid
-        hello — a peer that says hello, sends its registry, then closes. That
-        path has mirrored entries to clean up. Keyed on ``_stop``, the early
-        return skips ``clear_remote_agents`` and leaves them behind.
+        ``_stop`` is set by a plain EOF, not only by a refusal, so it can be set
+        here with a perfectly good ``peer_host`` — a peer that says hello, sends
+        its registry, then closes. That path has mirrored entries to clean up.
+
+        What this pins is the property, not an explanation of it. Measured as a
+        2x2 over the guard's predicate and the ``return``'s placement, exactly
+        one combination fails::
+
+            peer_host + inside try   green      _stop + inside try   green
+            peer_host + outside try  green      _stop + outside try  RED
+
+        So *either* change alone closes it, and this test does not distinguish
+        which — the shipped code keeps both because they fix it by different
+        mechanisms: ``peer_host`` makes the branch not apply, inside-``try``
+        makes it harmless.
 
         The race is one the main thread normally wins, so the wait is slowed
         harness-side to make the ordering deterministic rather than lucky.

--- a/tests/integration/test_bridge.py
+++ b/tests/integration/test_bridge.py
@@ -261,7 +261,7 @@ class TestPeerHostValidation:
 
         peer_r, peer_w = os.pipe()
         sent = io.BytesIO()
-        bridge = Bridge(
+        conn = Bridge(
             os.fdopen(peer_r, "rb"),
             sent,
             "kaladin",
@@ -270,19 +270,29 @@ class TestPeerHostValidation:
             sync_interval=10,
             recv_timeout=60,
         )
-        thread = threading.Thread(target=bridge.run, daemon=True)
+        thread = threading.Thread(target=conn.run, daemon=True)
         thread.start()
         with os.fdopen(peer_w, "wb") as peer:
             peer.write((json.dumps({"kind": "hello", "host": "*"}) + "\n").encode())
             peer.flush()
             thread.join(timeout=5.0)
 
-        assert not thread.is_alive(), "bridge should refuse and exit, not hang"
-        assert bridge.peer_host is None, "an invalid host must never be assigned"
-
+        # Leak assertions FIRST. Ordered deliberately: with the liveness check
+        # first, a regression that hangs reddens this test before the leak
+        # assertions are ever evaluated, so the test would report the wrong
+        # failure and the leak coverage would be silently unreachable.
         frames = [json.loads(x) for x in sent.getvalue().decode().splitlines() if x.strip()]
         bodies = [f["message"]["body"] for f in frames if f.get("kind") == "msg"]
         assert bodies == [], f"forwarded mail to a peer claiming '*': {bodies}"
+
+        kinds = [f.get("kind") for f in frames]
+        assert "registry" not in kinds, (
+            f"advertised the registry to a peer we refused: {kinds}. The frame carries "
+            "agent ids, names, absolute working directories, pids and focus text."
+        )
+
+        assert not thread.is_alive(), "bridge should refuse and exit, not hang"
+        assert conn.peer_host is None, "an invalid host must never be assigned"
 
     def test_valid_host_still_connects(self, tmp_path: Path) -> None:
         """Positive control: the rejection above is the validator firing, not the
@@ -290,7 +300,7 @@ class TestPeerHostValidation:
         store = StateStore(root=tmp_path / "local")
         _register_live(store, "agent-local", "local")
         peer_r, peer_w = os.pipe()
-        bridge = Bridge(
+        conn = Bridge(
             os.fdopen(peer_r, "rb"),
             io.BytesIO(),
             "kaladin",
@@ -299,12 +309,12 @@ class TestPeerHostValidation:
             sync_interval=10,
             recv_timeout=60,
         )
-        thread = threading.Thread(target=bridge.run, daemon=True)
+        thread = threading.Thread(target=conn.run, daemon=True)
         thread.start()
         with os.fdopen(peer_w, "wb") as peer:
             peer.write((json.dumps({"kind": "hello", "host": "adolin"}) + "\n").encode())
             peer.flush()
-            _wait(lambda: bridge.peer_host == "adolin")
-            bridge.stop()
+            _wait(lambda: conn.peer_host == "adolin")
+            conn.stop()
             thread.join(timeout=5.0)
-        assert bridge.peer_host == "adolin"
+        assert conn.peer_host == "adolin"

--- a/tests/integration/test_bridge.py
+++ b/tests/integration/test_bridge.py
@@ -7,6 +7,8 @@ agents mirror across and messages flow in both directions.
 
 from __future__ import annotations
 
+import io
+import json
 import os
 import subprocess
 import threading
@@ -16,8 +18,15 @@ from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock
 
+import pytest
+
+from spanreed import bridge
 from spanreed.bridge import Bridge, reconnect_loop
 from spanreed.store import StateStore
+
+# Aliased once so the private stays private — same pattern as test_cli.py's
+# `_parse_since`: one alias costs a single ignore instead of one per call site.
+_is_valid_host = bridge._is_valid_host  # pyright: ignore[reportPrivateUsage]
 
 
 def _wait(cond: Callable[[], bool], timeout: float = 5.0) -> None:
@@ -189,3 +198,113 @@ def test_reconnect_loop_stops_on_shutdown(tmp_path: Path) -> None:
         wait=no_wait,
     )
     assert len(spawns) == 1  # broke immediately after the first run
+
+
+class TestPeerHostValidation:
+    """The peer chooses its own host label; we interpolate it into ``Path.glob``.
+
+    A ``*`` there is a wildcard, not a name — ``*@*.jsonl`` matches every
+    host-qualified inbox, so a peer claiming ``host: "*"`` is handed mail queued
+    for unrelated hosts. The same string is compared as a *literal* suffix in
+    three other places (``_strip_peer``, ``sync_remote_agents``,
+    ``clear_remote_agents``), so one field is read two different ways.
+    """
+
+    @pytest.mark.parametrize(
+        "host",
+        ["kaladin", "adolin.lan", "host-1", "my_box", "a", "A1.b-c_d.example.com"],
+    )
+    def test_plausible_hostnames_are_accepted(self, host: str) -> None:
+        assert _is_valid_host(host)
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "*",  # the leak: glob matches every host-qualified inbox
+            "?",  # single-char wildcard
+            "[abc]",  # character class
+            "a*b",  # embedded wildcard
+            "",  # empty -> "*@.jsonl"
+            "..",  # path traversal shape
+            "a/b",  # separator
+            "a b",  # whitespace
+            "-lead",  # must start alphanumeric
+            "trail-",  # must end alphanumeric
+            "x" * 254,  # over the length cap
+        ],
+    )
+    def test_metacharacters_and_malformed_are_rejected(self, host: str) -> None:
+        assert not _is_valid_host(host)
+
+    def test_peer_claiming_star_gets_no_third_host_mail(self, tmp_path: Path) -> None:
+        """The reproduction this fix exists for, driven end to end.
+
+        Before validation this forwarded both inboxes to a peer entitled to
+        neither.
+        """
+        store = StateStore(root=tmp_path / "local")
+        _register_live(store, "agent-local", "local")
+        for host in ("thirdhost", "adolin"):
+            (store.root / "inboxes" / f"agent-zzz@{host}.jsonl").write_text(
+                json.dumps(
+                    {
+                        "msg_id": f"private-{host}",
+                        "from_agent": "agent-local",
+                        "to_agent": f"agent-zzz@{host}",
+                        "body": f"MAIL PRIVATE TO {host}",
+                        "ts": "2026-01-01T00:00:00Z",
+                        "in_reply_to": None,
+                    }
+                )
+                + "\n"
+            )
+
+        peer_r, peer_w = os.pipe()
+        sent = io.BytesIO()
+        bridge = Bridge(
+            os.fdopen(peer_r, "rb"),
+            sent,
+            "kaladin",
+            store,
+            poll_interval=0.05,
+            sync_interval=10,
+            recv_timeout=60,
+        )
+        thread = threading.Thread(target=bridge.run, daemon=True)
+        thread.start()
+        with os.fdopen(peer_w, "wb") as peer:
+            peer.write((json.dumps({"kind": "hello", "host": "*"}) + "\n").encode())
+            peer.flush()
+            thread.join(timeout=5.0)
+
+        assert not thread.is_alive(), "bridge should refuse and exit, not hang"
+        assert bridge.peer_host is None, "an invalid host must never be assigned"
+
+        frames = [json.loads(x) for x in sent.getvalue().decode().splitlines() if x.strip()]
+        bodies = [f["message"]["body"] for f in frames if f.get("kind") == "msg"]
+        assert bodies == [], f"forwarded mail to a peer claiming '*': {bodies}"
+
+    def test_valid_host_still_connects(self, tmp_path: Path) -> None:
+        """Positive control: the rejection above is the validator firing, not the
+        harness failing to connect."""
+        store = StateStore(root=tmp_path / "local")
+        _register_live(store, "agent-local", "local")
+        peer_r, peer_w = os.pipe()
+        bridge = Bridge(
+            os.fdopen(peer_r, "rb"),
+            io.BytesIO(),
+            "kaladin",
+            store,
+            poll_interval=0.05,
+            sync_interval=10,
+            recv_timeout=60,
+        )
+        thread = threading.Thread(target=bridge.run, daemon=True)
+        thread.start()
+        with os.fdopen(peer_w, "wb") as peer:
+            peer.write((json.dumps({"kind": "hello", "host": "adolin"}) + "\n").encode())
+            peer.flush()
+            _wait(lambda: bridge.peer_host == "adolin")
+            bridge.stop()
+            thread.join(timeout=5.0)
+        assert bridge.peer_host == "adolin"

--- a/tests/integration/test_bridge.py
+++ b/tests/integration/test_bridge.py
@@ -318,3 +318,69 @@ class TestPeerHostValidation:
             conn.stop()
             thread.join(timeout=5.0)
         assert conn.peer_host == "adolin"
+
+    def test_eof_after_a_valid_hello_still_tears_down_mirrored_entries(
+        self, tmp_path: Path
+    ) -> None:
+        """The refusal guard must key on ``peer_host``, not on ``_stop``.
+
+        ``_stop`` is set by a plain EOF too, and an EOF can land *after* a valid
+        hello — a peer that says hello, sends its registry, then closes. That
+        path has mirrored entries to clean up. Keyed on ``_stop``, the early
+        return skips ``clear_remote_agents`` and leaves them behind.
+
+        The race is one the main thread normally wins, so the wait is slowed
+        harness-side to make the ordering deterministic rather than lucky.
+        """
+        store = StateStore(root=tmp_path / "local")
+        _register_live(store, "agent-local", "local")
+
+        peer_r, peer_w = os.pipe()
+        conn = Bridge(
+            os.fdopen(peer_r, "rb"),
+            io.BytesIO(),
+            "kaladin",
+            store,
+            poll_interval=0.05,
+            sync_interval=10,
+            recv_timeout=60,
+        )
+        real_wait = conn._hello.wait  # pyright: ignore[reportPrivateUsage]
+
+        def slow_wait(timeout: float | None = None) -> bool:
+            result = real_wait(timeout)
+            time.sleep(0.3)  # let the reader hit EOF and set _stop before we proceed
+            return result
+
+        conn._hello.wait = slow_wait  # type: ignore[method-assign]
+
+        with os.fdopen(peer_w, "wb") as peer:
+            peer.write((json.dumps({"kind": "hello", "host": "adolin"}) + "\n").encode())
+            peer.write(
+                (
+                    json.dumps(
+                        {
+                            "kind": "registry",
+                            "agents": [
+                                {
+                                    "agent_id": "agent-remote",
+                                    "name": "remote",
+                                    "working_dir": "/tmp",
+                                    "pid": os.getpid(),
+                                    "pid_start": None,
+                                    "last_seen": "2026-01-01T00:00:00Z",
+                                }
+                            ],
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+            peer.flush()
+        thread = threading.Thread(target=conn.run, daemon=True)
+        thread.start()
+        thread.join(timeout=5.0)
+
+        assert not thread.is_alive()
+        mirrored = [a.agent_id for a in store.list_agents(include_stale=True) if "@" in a.agent_id]
+        assert mirrored == [], f"EOF after a valid hello left mirrored entries behind: {mirrored}"


### PR DESCRIPTION
Refs #17.

The peer chooses its own host label in the `hello` frame, and the receiver interpolates it straight into `Path.glob` when selecting which outbound inboxes to forward. **A `*` there is a wildcard, not a name.**

## The leak, reproduced end to end

Two inboxes staged for two unrelated hosts, then a peer connects claiming `host: "*"`:

```
before:  peer_host accepted = '*'
         forwarded: to_agent='agent-zzz@adolin'     body='MAIL PRIVATE TO adolin'
                    to_agent='agent-zzz@thirdhost'  body='MAIL PRIVATE TO thirdhost'

after:   bridge refuses the hello and exits; peer_host stays None; nothing forwarded
```

The test drives a real `Bridge` over a real `os.pipe()`, not a `BytesIO` — an earlier version of this reproduction returned a false clean because the buffer hit EOF and stopped the loop before the forward pass ran.

## The deeper inconsistency

One field is read two different ways:

```
_forward_outbound      glob(f"*@{peer_host}.jsonl")     <- pattern
_strip_peer            endswith(f"@{peer_host}")        <- literal
sync_remote_agents     endswith(f"@{home_host}")        <- literal
clear_remote_agents    endswith(f"@{home_host}")        <- literal
```

The four disagree about what the value means, and only the glob is exploitable. `"*"` is just the cleanest way to demonstrate it — any host whose name contains `*`, `?` or `[` gets non-deterministic forwarding with no error and no log line.

## Why this didn't wait on #16

**Input validation, not a protocol change.** It does not alter what the bridge trusts, what it forwards, or the frame format — it stops a value that was never meant to be a pattern from reaching a matcher. Correct under any answer to the sender-trust question, which is now settled (#16, merged) and didn't change it either way.

## Choices worth challenging

- **Permissive charset, strict metacharacters.** Alphanumeric at both ends, `.`/`-`/`_` inside, ≤253 chars. An SSH target is often an alias from `~/.ssh/config` rather than a DNS name, so refusing an unusual-but-legitimate host would be its own bug. Rejects globs, separators, whitespace, empty.
- **Refuse rather than fall back.** There is no safe default for *"which host's mail should I forward"*, so an invalid label exits the bridge instead of guessing. Message goes to stderr — stdout **is** the pipe.
- **`_is_valid_host` is private, aliased once in the test** with a single `pyright: ignore`, matching the precedent set for `_parse_since` in `test_cli.py`. Repo now has exactly two such ignores.

## A second leak, found in review — the one that mattered more

The refusal path set `_hello` to release `run()`'s wait, and `run()` sends the registry unconditionally once that wait returns. **So the signal meaning "hang up" was the signal that let the advertisement through.** A peer claiming `host: "*"` was refused and then handed:

```
agent-04610969  name=spanreed  wd=/home/jmonk/git/spanreed  pid=...  focus='auditing the bus trust model'
```

Agent ids, display names, **absolute working directories**, pids, free-text focus. Now `['hello']` only.

*"The peer already has SSH"* does not excuse it — that argument would excuse the whole PR, which is premised on a peer that lies about its host.

**My own test could not see it.** It filtered to `kind == "msg"`, so an implementation that hangs up *and* hands over the registry passed every assertion in the diff. The test now checks frame kinds too, and its assertions are reordered: the liveness check ran first, so a regression that hangs would redden the test before either leak assertion was evaluated — reporting the wrong failure and leaving the leak coverage unreachable.

## Verification

- Both guards independently demonstrated RED: removing the registry guard fails **exactly one** test; disabling the validator fails **12**. Restoring gives 23 passed in that file.
- A positive control asserts a valid host still connects, so the rejection is the validator firing rather than the handshake failing.
- `docs/protocol.md` now documents the `hello` frame, which it previously did not describe at all, and states the validation rule — per the repo's doc-first rule for anything touching the wire format.

`make check` green, 171 tests (was 166).
