### PR TITLE
tests: pin the pid-zero guard, the one value its own comment is about

### DIFF
--- a/tests/unit/test_session_identity.py
+++ b/tests/unit/test_session_identity.py
@@ -104,7 +104,7 @@ class TestFallsBackWhereItShould:
 
         assert session_agent_identity(wd) == (*derive_agent_identity(wd), None)
 
-    @pytest.mark.parametrize("junk", ["", "not-a-pid", "12x", "-1"])
+    @pytest.mark.parametrize("junk", ["0", "", "not-a-pid", "12x", "-1"])
     def test_unusable_claude_pid_uses_the_directory(
         self, bus: StateStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, junk: str
     ) -> None:
@@ -394,7 +394,15 @@ class TestSessionPid:
         monkeypatch.delenv("CLAUDE_PID", raising=False)
         assert session_pid() == os.getppid()
 
-    @pytest.mark.parametrize("junk", ["", "not-a-pid", "12x", "-1", " 5"])
+    # "0" is listed FIRST because it is the only value the `> 0` guard exists
+    # for, and it was the one value this list omitted. Everything else here is
+    # rejected by `.isdigit()` alone; deleting the guard left the whole suite
+    # green. `session_pid`'s own comment explains why 0 is the dangerous one —
+    # `os.kill(0, 0)` signals the process group rather than probing a process,
+    # so an entry recorded with pid 0 reads live forever — and then nothing
+    # tested it. A guard whose rationale is written down and whose rationale is
+    # untested is the shape this repo keeps finding.
+    @pytest.mark.parametrize("junk", ["0", "", "not-a-pid", "12x", "-1", " 5"])
     def test_unusable_claude_pid_falls_back(
         self, monkeypatch: pytest.MonkeyPatch, junk: str
     ) -> None:

--- a/tests/unit/test_session_identity.py
+++ b/tests/unit/test_session_identity.py
@@ -113,8 +113,8 @@ class TestFallsBackWhereItShould:
     #
     # A case that DID discriminate cannot be written, because the behaviour it
     # would assert is wrong: a pid-0 entry has pid_start=None, so is_stale() is
-    # False forever, and this function adopts it. Tracked separately; the guard
-    # in session_pid() is one layer of two.
+    # False forever, and this function adopts it. Tracked as #50; the guard in
+    # session_pid() is one layer of two.
     @pytest.mark.parametrize("junk", ["", "not-a-pid", "12x", "-1"])
     def test_unusable_claude_pid_uses_the_directory(
         self, bus: StateStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, junk: str
@@ -407,12 +407,12 @@ class TestSessionPid:
 
     # "0" is listed FIRST because it is the only value the `> 0` guard exists
     # for, and it was the one value this list omitted. Everything else here is
-    # rejected by `.isdigit()` alone; deleting the guard left the whole suite
-    # green. `session_pid`'s own comment explains why 0 is the dangerous one —
-    # `os.kill(0, 0)` signals the process group rather than probing a process,
-    # so an entry recorded with pid 0 reads live forever — and then nothing
-    # tested it. A guard whose rationale is written down and whose rationale is
-    # untested is the shape this repo keeps finding.
+    # rejected by `.isdigit()` alone, so before this case was added, deleting
+    # the guard left the whole suite green. `session_pid`'s own comment explains
+    # why 0 is the dangerous one — `os.kill(0, 0)` signals the process group
+    # rather than probing a process, so an entry recorded with pid 0 reads live
+    # forever — and nothing tested it. A guard whose rationale is written down
+    # and whose rationale is untested is the shape this repo keeps finding.
     @pytest.mark.parametrize("junk", ["0", "", "not-a-pid", "12x", "-1", " 5"])
     def test_unusable_claude_pid_falls_back(
         self, monkeypatch: pytest.MonkeyPatch, junk: str

--- a/tests/unit/test_session_identity.py
+++ b/tests/unit/test_session_identity.py
@@ -104,7 +104,18 @@ class TestFallsBackWhereItShould:
 
         assert session_agent_identity(wd) == (*derive_agent_identity(wd), None)
 
-    @pytest.mark.parametrize("junk", ["0", "", "not-a-pid", "12x", "-1"])
+    # No "0" here, deliberately, and the reason is a defect rather than a
+    # tidy-up. `session_agent_identity` guards with `.isdigit()` alone
+    # (identity.py:89) and has no `> 0` check, so "0" would NOT exercise
+    # validation — it passes the digit test, reaches the registry lookup, finds
+    # nothing, and exits through the already-covered no-match branch. It would
+    # read as guard coverage and be none.
+    #
+    # A case that DID discriminate cannot be written, because the behaviour it
+    # would assert is wrong: a pid-0 entry has pid_start=None, so is_stale() is
+    # False forever, and this function adopts it. Tracked separately; the guard
+    # in session_pid() is one layer of two.
+    @pytest.mark.parametrize("junk", ["", "not-a-pid", "12x", "-1"])
     def test_unusable_claude_pid_uses_the_directory(
         self, bus: StateStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, junk: str
     ) -> None:


### PR DESCRIPTION
Found by the 2026-09-02 code-health pass, which listed it **below its top-5 cut** and relayed it rather than dropping it.

## The gap

`session_pid()` rejects `"0"` specifically, and its comment says why:

> `> 0` matters: pid 0 passes `isdigit()`, and `os.kill(0, 0)` signals the whole process group rather than probing a process — so an entry recorded with pid 0 reads live forever, which is the fail-open shape this rule exists to prevent.

The parametrized list of unusable `CLAUDE_PID` values was `["", "not-a-pid", "12x", "-1", " 5"]`. **Every one of those is rejected by `.isdigit()` alone.** The single value that needs the `> 0` guard was the one not listed, so deleting the guard left the suite green.

> a guard whose rationale is written down, and whose rationale is untested

## What actually changed, after review

**One list, not two.** My first version added `"0"` to both parametrized lists. Review found the second one **inert**: `session_agent_identity` (`identity.py:89`) validates with `.isdigit()` alone and has no `> 0` check, so `"0"` there passes the digit test, reaches the registry lookup, finds nothing, and exits through an already-covered branch. **It read as guard coverage and was none** — this PR's own defect, committed inside the fix for it.

The signal was in the output I had already printed: the mutation reddened *one* test, not two. I put that number in this body and never asked why it was not two.

It is removed rather than kept with a caveat, for two reasons:

- a parametrized case is an assertion, and the only thing that one could assert is "`CLAUDE_PID=0` falls back" — true for a reason unrelated to validation. A caveat is what gets skipped at the speed people read parametrize lists.
- it was green only because that test class's registry fixture is empty. Any future change putting a pid-0 entry in that class flips it red — correctly — and whoever made that change would triage it as a regression they caused.

A comment now states the one thing a present case cannot: **why it is absent.**

## The defect underneath, filed as #50

A case that *did* discriminate there cannot be written, because the behaviour it would assert is wrong:

```
register_agent(pid=0)  ->  pid_start=None  ->  is_stale=False, permanently
list_agents()          ->  entry visible
session_agent_identity with CLAUDE_PID=0, cwd elsewhere  ->  ADOPTS it
```

`session_pid()`'s guard is **one layer of two** — `store.register_agent` validates no pid at all, and `_ensure_registered` and the bridge's mirroring bypass it.

## Verification

`make check` clean. **245 → 246 tests** (one parametrize case). Deleting the `> 0` guard reds `test_unusable_claude_pid_falls_back[0]`, where before it reddened nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BBLGX2riVjxco6khkiabF
