### PR TITLE
docs: record the single-sourcing question where questions live

### DIFF
--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -15,6 +15,10 @@ Things still to test, design, or decide.
 ## Design
 
 - **MCP tool surface**: final shape of `register`, `send`, `recv`. Acknowledgments? Read receipts? Conversation threading?
+- **Single-sourcing published tool descriptions**: `MCPServer.tool()` accepts `description=`, so a tool's docstring and its *published* description could be one string instead of two. Raised by the review of #42 and deferred rather than decided.
+  - **What it fixes.** Not "the two copies disagreeing" — that framing is wrong, and getting it wrong is how #14 stayed live. #14's harm was **asymmetric visibility**: the false copy was the published one (in every agent's context) and the true copy was in `store.py`, which no agent reads. Single-sourcing puts the human editing the docstring in front of the exact bytes the agent receives, so the reader best placed to catch an error finally looks at the published artifact.
+  - **What it does not fix.** It unifies the two *Python* copies only. `docs/protocol.md` remains a third, so it would have addressed two of #14's three locations. A single wrong string is still wrong — it removes the asymmetry, not the falsehood — so it never substitutes for a description guard. The code/spec edge it leaves open is exactly where #44 sits.
+  - **Suggested scope if taken**: the few tools carrying load-bearing semantics (`wait_for_reply`, `register_agent`), not file-wide. Related: #14, #42, #44.
 - **State format**: JSONL append-only? SQLite? File-per-message?
 - **Agent identity**: what makes two sessions "the same agent" vs. distinct? Working directory? Manual name? PID?
 - **Conversation continuity**: can a message reference a thread, and Claude pick up context from prior messages in it?


### PR DESCRIPTION
Four lines in `docs/open-questions.md`. Opened late — the branch was pushed on 2026-09-02 and I never filed the PR, so it sat on the remote unreferenced for nearly two weeks. Found by sweeping for remote branches with no PR, which is worth doing periodically: a pushed branch nobody opened is indistinguishable from work that was never done.

## What it records

Whether a tool's docstring and its **published** description should be one string — `MCPServer.tool()` accepts `description=`. Raised by the review of #42, deferred rather than decided.

## Why `open-questions.md` and not an issue

My first plan was to park it in **#44**'s scope note. The reviewer disagreed on repo grounds and was right: **#44 is a bug issue that closes when `register_agent` is fixed**, so a deferred design decision riding in its scope note is not deferred, it is buried — findable only by someone already searching closed issues for a question they do not know exists.

CLAUDE.md rule 4 names the right home, and the file already has a `## Design` section with an `MCP tool surface` bullet this sits directly under. It is also not independently actionable, which is why it belongs in the file for questions rather than the tracker for work.

## Two things the entry gets right that I had backwards

- **It does not fix "the two copies disagree."** That framing is what let #14 stay live. The harm was **asymmetric visibility** — the false copy was the published one, in every agent's context, and the true copy was in `store.py`, which no agent reads. Single-sourcing puts the human editing the docstring in front of the exact bytes the agent receives.
- **It is narrower than I assumed.** It unifies the two *Python* copies only; `docs/protocol.md` stays a third. So it would have fixed two of #14's three locations, and the code/spec edge it leaves open is exactly where **#44** sits.

Both corrections came from the reviewer, and both are in the recorded text rather than only in this description.

## Verification

Docs only, no code. `make check` clean on the branch at the time of writing; it is 1 commit behind `main` and does not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BBLGX2riVjxco6khkiabF
